### PR TITLE
Change .gitmodules link from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "KiCad_Library"]
 	path = KiCad_Library
-	url = git@github.com:ut-ras/KiCad_Library.git
+	url = https://github.com/ut-ras/KiCad_Library.git


### PR DESCRIPTION
Because people have been having issues with SSH keys and their computers ggggggggggggggggg

:smile::smile::smile::smile::smile::smile::smile::smile::smile::smile::smile::smile::smile::smile::smile::smile::smile::smile: